### PR TITLE
Load graph from existing yaml (refactor)

### DIFF
--- a/stations.yml
+++ b/stations.yml
@@ -1,111 +1,211 @@
 ---
 amazon:
+  connections:
+    - walker
+    - mind_flayer
+  coordinates:
     x: 400
     y: 68
     z: -168
 badlands_hole:
+  connections:
+    - shin_sealab
+  coordinates:
     x: -183
     y: 87
     z: -799
 desert:
+  connections:
+    - joshua_desert
+    - thomas_desert
+  coordinates:
     x: 218
     y: 47
     z: 250
 farfetchd:
+  connections:
+    - joshlantis
+    - shin_sealab
+  coordinates:
     x: -244
     y: 82
     z: -826
 hole:
+  connections:
+    - main_thomas
+    - icy_spikes
+  coordinates:
     x: -134
     y: 72
     z: 40
 icy_spikes:
+  connections:
+    - hole
+    - main_shin
+  coordinates:
     x: -70
     y: 73
     z: -51
 isle_of_jason:
+  connections:
+#    - sealab
+    - shin_sealab
+  coordinates:
     x: -355
     y: 56
     z: -778
 jason:
+  connections:
+    - joshua_desert
+    - south
+  coordinates:
     x: -56
     y: 76
     z: 69
 jason_valley:
+  connections:
+    - shin_walker
+    - shin_sealab
+  coordinates:
     x: -244
     y: 78
     z: -746
 joshlantis:
+  connections:
+    - farfetchd
+  coordinates:
     x: -128
     y: 86
     z: -1004
 joshua:
+  connections:
+    - main_walker
+    - joshua_desert
+  coordinates:
     x: -3
     y: 68
     z: 31
 jungle:
+  connections:
+    - thomas_blake
+    - stronghold2point0
+  coordinates:
     x: -247
     y: 68
     z: 288
 ksenia:
+  connections:
+    - shin_walker
+    - walker
+  coordinates:
     x: -61
     y: 85
     z: -201
 matrejek_meadows:
+  connections:
+    - matrejek_meadows_sheep
+    - main_thomas
+  coordinates:
     x: -186
     y: 77
     z: 75
 matrejek_meadows_sheep:
+  connections:
+    - matrejek_meadows
+    - thomas_blake
+  coordinates:
     x: -198
     y: 69
     z: 91
 mind_flayer:
+  connections:
+    - amazon
+    - roanoke
+  coordinates:
     x: 360
     y: 69
     z: -94
 new_blakeland:
+  connections:
+    - thomas_blake
+  coordinates:
     x: -279
     y: 87
     z: 64
 # north:
-# 
+#   connections:
+#   coordinates:
+#
 #     x: 0
 #     y: 0
 #     z: 0
 roanoke:
+  connections:
+    - mind_flayer
+    - main_walker
+  coordinates:
     x: 167
     y: 79
     z: -25
 # sealab:
-# 
+#   connections:
+#     - isle_of_jason
+#   coordinates:
 #     x: 0
 #     y: 0
 #     z: 0
 south:
+  connections:
+    - jason
+    - main_thomas
+  coordinates:
     x: -98
     y: 74
     z: 77
 stronghold:
+  connections:
+    - main_shin
+    - shin_walker
+  coordinates:
     x: -123
     y: 88
     z: -139
 stronghold2point0:
+  connections:
+    - jungle
+    - thomas_desert
+  coordinates:
     x: -98
     y: 38
     z: 300
 supermax:
+  connections:
+    - thomas_desert
+    - walker_keep
+  coordinates:
     x: 218
     y: 48
     z: 291
 walker:
+  connections:
+    - ksenia
+    - amazon
+  coordinates:
     x: 256
     y: 55
     z: -303
 walker_keep:
+  connections:
+    - supermax
+  coordinates:
     x: 258
     y: 48
     z: 476
 welcome_center:
+  connections:
+    - main_walker
+    - main_shin
+  coordinates:
     x: -7
     y: 50
     z: -17

--- a/switches.yml
+++ b/switches.yml
@@ -1,33 +1,106 @@
 ---
-sw1:
-  x: -244
-  y: 77
-  z: -778
-sw2:
-  x: -123
-  y: 87
-  z: -156
-sw3:
-  x: -70
-  y: 72
-  z: -59
-sw4:
-  x: -7
-  y: 49
-  z: -10
-sw5:
-  x: -3
-  y: 67
-  z: 36
-sw6:
-  x: -145
-  y: 71
-  z: 34
-sw7:
-  x: -251
-  y: 70
-  z: 100
-sw8:
-  x: 218
-  y: 47
-  z: 286
+shin_sealab:
+  connections:
+    farfetchd:
+      dir: "N"
+    badlands_hole:
+      dir: "E"
+    jason_valley:
+      dir: "S"
+    isle_of_jason:
+      dir: "W"
+  coordinates:
+    x: -244
+    y: 77
+    z: -778
+
+shin_walker:
+  connections:
+    jason_valley:
+      dir: "N"
+    ksenia:
+      dir: "E"
+    stronghold:
+      dir: "S"
+  coordinates:
+    x: -123
+    y: 87
+    z: -156
+
+main_shin:
+  connections:
+    welcome_center:
+      dir: "E"
+    icy_spikes:
+      dir: "S"
+    stronghold:
+      dir: "W"
+  coordinates:
+    x: -70
+    y: 72
+    z: -59
+
+main_walker:
+  connections:
+    welcome_center:
+      dir: "N"
+    roanoke:
+      dir: "E"
+    joshua:
+      dir: "S"
+  coordinates:
+    x: -7
+    y: 49
+    z: -10
+
+joshua_desert:
+  connections:
+    joshua:
+      dir: "N"
+    desert:
+      dir: "E"
+    jason:
+      dir: "W"
+  coordinates:
+    x: -3
+    y: 67
+    z: 36
+
+main_thomas:
+  connections:
+    hole:
+      dir: "E"
+    south:
+      dir: "S"
+    matrejek_meadows:
+      dir: "W"
+  coordinates:
+    x: -145
+    y: 71
+    z: 34
+
+thomas_blake:
+  connections:
+    matrejek_meadows_sheep:
+      dir: "N"
+    jungle:
+      dir: "S"
+    new_blakeland:
+      dir: "W"
+  coordinates:
+    x: -251
+    y: 70
+    z: 100
+
+thomas_desert:
+  connections:
+    desert:
+      dir: "N"
+    supermax:
+      dir: "S"
+    stronghold2point0:
+      dir: "W"
+  coordinates:
+    x: 218
+    y: 47
+    z: 286


### PR DESCRIPTION
Instead of generating the graph by adding edges one function call at a time, load the entire graph by loading existing YAML for switches and stations.

Changes:
* both stations.yml and switches.yml have top-level keys for each station, connections and coordinates
*  create 4 dictionaries; 2 for stations, 2 for switches, one storing names mapped to coordinate sets, one storing names mapped to connection data
* rename "combined_yaml" to "all_coordinates", since that's what it is.
* give switches meaningful names
* uncomment sealab